### PR TITLE
[밥 먹언] 검색 기능 API 구현 및 유닛 테스트 구현 (places/views.py) (places/tests.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,4 @@ my_settings.py
 
 db_uploader.py
 csv_upload
+decorators.py

--- a/bob_morgan/urls.py
+++ b/bob_morgan/urls.py
@@ -16,5 +16,5 @@ Including another URLconf
 from django.urls import path, include
 
 urlpatterns = [
-    path('users', include('users.urls')),
+    path('places', include('places.urls')),
 ]

--- a/decorators.py
+++ b/decorators.py
@@ -1,0 +1,20 @@
+import functools, time
+from django.db   import connection, reset_queries
+from django.conf import settings
+
+def query_debugger(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        reset_queries()
+        number_of_start_queries = len(connection.queries)
+        start  = time.perf_counter()
+        result = func(*args, **kwargs)
+        end    = time.perf_counter()
+        number_of_end_queries = len(connection.queries) - 2 if len(connection.queries) else 0
+        print(f"-------------------------------------------------------------------")
+        print(f"Function : {func.__name__}")
+        print(f"Number of Queries : {number_of_end_queries-number_of_start_queries}")
+        print(f"Finished in : {(end - start):.2f}s")
+        print(f"-------------------------------------------------------------------")
+        return result
+    return wrapper

--- a/places/models.py
+++ b/places/models.py
@@ -1,3 +1,4 @@
+
 from django.db import models
 
 class Place(models.Model):
@@ -57,4 +58,5 @@ class Region(models.Model):
 
     class Meta:
         db_table = 'regions'
+
 

--- a/places/tests.py
+++ b/places/tests.py
@@ -1,3 +1,256 @@
-from django.test import TestCase
+from django.test import TestCase, Client
 
-# Create your tests here.
+from places.models import Place, PlaceMenu, Menu, Price, Category, Image, Region
+
+class PlaceSearchViewTest(TestCase):
+    def setUp(self):
+        Menu.objects.bulk_create([
+            Menu(id = 1, name = '까눌레'),
+            Menu(id = 2, name = '아메리카노'),
+            Menu(id = 3, name = '핸드드립'),
+            Menu(id = 4, name = '흑돼지고기국수'),
+            Menu(id = 5, name = '돔베고기'),
+            Menu(id = 6, name = '흑돼지비빔국수'),
+        ])
+        Price.objects.bulk_create([
+            Price(id = 6, price = '3000'),
+            Price(id = 10, price = '5000'),
+            Price(id = 12, price = '6000'),
+            Price(id = 16, price = '8000'),
+            Price(id = 56, price = '28000'),
+        ])
+        Category.objects.bulk_create([
+            Category(id = 1, name = '한식'),
+            Category(id = 5, name = '카페'),
+        ])
+        Region.objects.bulk_create([
+            Region(id = 2, name = '애월_한림'),
+            Region(id = 4, name = '성산_표선'),
+        ])
+        Place.objects.bulk_create([
+            Place(
+                id                           = 1,
+                name                         = '토투가커피',
+                address                      = '제주특별자치도 제주시 한림읍 귀덕9길 19',
+                phone_number                 = '010-6886-6121',
+                opening_hours                = '10:00 - 18:00, 연중무휴',
+                description                  = '맞아, 까눌레는 이래야지! 라는 말이 절로 나오는 집!',
+                maximum_number_of_subscriber = '0',
+                latitude                     = '33.44283842',
+                longitude                    = '126.289942',
+                able_to_reserve              =  False,
+                closed_temporarily           =  False,
+                category_id                  = '5',
+                region_id                    = '2',
+            ),
+            Place(
+                id                           = 2,
+                name                         = '꽃가람',
+                address                      = '제주특별자치도 서귀포시 성산읍 고성동서로 73',
+                phone_number                 = '064-783-3939',
+                opening_hours                = '09:10 - 20:00, 매 주 목요일 휴무',
+                description                  = '담백하고 깔끔한 고기국수를 맛볼 수 있는 곳!',
+                maximum_number_of_subscriber = '6',
+                latitude                     = '33.45089738',
+                longitude                    = '126.9149578',
+                able_to_reserve              =  True,
+                closed_temporarily           =  False,
+                category_id                  = '1',
+                region_id                    = '4',
+            )
+        ])
+        PlaceMenu.objects.bulk_create([
+            PlaceMenu(menu_id = 1, place_id = 1, price_id = 6, is_signature = True),
+            PlaceMenu(menu_id = 2, place_id = 1, price_id = 10, is_signature = True),
+            PlaceMenu(menu_id = 3, place_id = 1, price_id = 12, is_signature = False),
+            PlaceMenu(menu_id = 4, place_id = 2, price_id = 16, is_signature = True),
+            PlaceMenu(menu_id = 5, place_id = 2, price_id = 56, is_signature = True),
+            PlaceMenu(menu_id = 6, place_id = 2, price_id = 16, is_signature = False),
+        ])
+        Image.objects.bulk_create([
+            Image(image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg', place_id  = 1),
+            Image(image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_TEPcAJMy_8808aea72589ba335d85f349ce8729bbb4144445.jpeg', place_id  = 2),
+        ])
+
+
+    def tearDown(self):
+        Menu.objects.all().delete()
+        Price.objects.all().delete()
+        Category.objects.all().delete()
+        Region.objects.all().delete()
+        Place.objects.all().delete()
+        PlaceMenu.objects.all().delete()
+        Image.objects.all().delete()
+
+    def test_success_place_search_get(self):
+        client = Client()
+
+        response = client.get('/places/search?date=2022-02-07')
+
+        self.assertEqual(response.json(),{
+            "results": [
+                {
+                    "place_id": 1,
+                    "place_name": "토투가커피",
+                    "place_opening_hours": "10:00 - 18:00, 연중무휴",
+                    "place_maximum_number_of_subscriber": 0,
+                    "place_able_to_reserve": False,
+                    "place_closed_temporarily": False,
+                    "place_category": "카페",
+                    "place_region": "애월_한림",
+                    "place_image": "https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg",
+                    "menus": [
+                        {
+                            "id": 1,
+                            "name": "까눌레",
+                            "price": "3000",
+                            "is_signature": True
+                        },
+                        {
+                            "id": 2,
+                            "name": "아메리카노",
+                            "price": "5000",
+                            "is_signature": True
+                        },
+                        {
+                            "id": 3,
+                            "name": "핸드드립",
+                            "price": "6000",
+                            "is_signature": False
+                        }
+                    ],
+                    "menu_avg_price": "4666.6667",
+                    "menu_min_price": "3000",
+                    "menu_max_price": "6000"
+                },
+                {
+                    "place_id": 2,
+                    "place_name": "꽃가람",
+                    "place_opening_hours": "09:10 - 20:00, 매 주 목요일 휴무",
+                    "place_maximum_number_of_subscriber": 6,
+                    "place_able_to_reserve": True,
+                    "place_closed_temporarily": False,
+                    "place_category": "한식",
+                    "place_region": "성산_표선",
+                    "place_image": "https://mustgo.carmore.kr/data/file/matzip/977797506_TEPcAJMy_8808aea72589ba335d85f349ce8729bbb4144445.jpeg",
+                    "menus": [
+                        {
+                            "id": 4,
+                            "name": "흑돼지고기국수",
+                            "price": "8000",
+                            "is_signature": True
+                        },
+                        {
+                            "id": 5,
+                            "name": "돔베고기",
+                            "price": "28000",
+                            "is_signature": True
+                        },
+                        {
+                            "id": 6,
+                            "name": "흑돼지비빔국수",
+                            "price": "8000",
+                            "is_signature": False
+                        }
+                    ],
+                    "menu_avg_price": "14666.6667",
+                    "menu_min_price": "8000",
+                    "menu_max_price": "28000"
+                }
+            ],
+            "date": "2022-02-07"
+        })
+        self.assertEqual(response.status_code, 200)
+
+    def test_success_place_search_get_filtered_by_categories(self):
+            client = Client()
+
+            response = client.get('/places/search?date=2022-02-07&category=5')
+
+            self.assertEqual(response.json(),{
+                "results": [
+                    {
+                        "place_id": 1,
+                        "place_name": "토투가커피",
+                        "place_opening_hours": "10:00 - 18:00, 연중무휴",
+                        "place_maximum_number_of_subscriber": 0,
+                        "place_able_to_reserve": False,
+                        "place_closed_temporarily": False,
+                        "place_category": "카페",
+                        "place_region": "애월_한림",
+                        "place_image": "https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg",
+                        "menus": [
+                            {
+                                "id": 1,
+                                "name": "까눌레",
+                                "price": "3000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 2,
+                                "name": "아메리카노",
+                                "price": "5000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 3,
+                                "name": "핸드드립",
+                                "price": "6000",
+                                "is_signature": False
+                            }
+                        ],
+                        "menu_avg_price": "4666.6667",
+                        "menu_min_price": "3000",
+                        "menu_max_price": "6000"
+                    }
+                ],
+                "date": "2022-02-07"
+            })
+            self.assertEqual(response.status_code, 200)
+
+    def test_success_place_search_get_filtered_by_regions(self):
+            client = Client()
+
+            response = client.get('/places/search?date=2022-02-07&region=4')
+
+            self.assertEqual(response.json(),{
+
+                "results": [
+                    {
+                        "place_id": 2,
+                        "place_name": "꽃가람",
+                        "place_opening_hours": "09:10 - 20:00, 매 주 목요일 휴무",
+                        "place_maximum_number_of_subscriber": 6,
+                        "place_able_to_reserve": True,
+                        "place_closed_temporarily": False,
+                        "place_category": "한식",
+                        "place_region": "성산_표선",
+                        "place_image": "https://mustgo.carmore.kr/data/file/matzip/977797506_TEPcAJMy_8808aea72589ba335d85f349ce8729bbb4144445.jpeg",
+                        "menus": [
+                            {
+                                "id": 4,
+                                "name": "흑돼지고기국수",
+                                "price": "8000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 5,
+                                "name": "돔베고기",
+                                "price": "28000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 6,
+                                "name": "흑돼지비빔국수",
+                                "price": "8000",
+                                "is_signature": False
+                            }
+                        ],
+                        "menu_avg_price": "14666.6667",
+                        "menu_min_price": "8000",
+                        "menu_max_price": "28000"
+                    }
+                ],
+                "date": "2022-02-07"
+            })
+            self.assertEqual(response.status_code, 200)

--- a/places/urls.py
+++ b/places/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from places.views import PlaceSearchView, CategoryListView, RegionListView
+
+urlpatterns = [
+    path('/search', PlaceSearchView.as_view()),
+    path('/category', CategoryListView.as_view()),
+    path('/region', RegionListView.as_view())
+]

--- a/places/views.py
+++ b/places/views.py
@@ -1,3 +1,85 @@
-from django.shortcuts import render
+from django.http      import JsonResponse
+from django.views     import View
+from django.db.models import Q, Avg, Min, Max
 
-# Create your views here.
+from places.models import Place, Category, Region
+
+class CategoryListView(View):
+    def get(self, request):
+        result = [{
+            'category_id'   : category.id,
+            'category_name' : category.name
+        } for category in Category.objects.all()]
+
+        return JsonResponse({'category_list' : result}, status = 200)
+
+class RegionListView(View):
+    def get(self, request):
+        result = [{
+            'region_id' : region.id,
+            'region_name' : region.name
+        } for region in Region.objects.all()]
+
+        return JsonResponse({'region_list' : result}, status = 200)
+
+class PlaceSearchView(View):
+    def get(self, request):
+        try:
+            date       = request.GET.get('date')
+            regions    = request.GET.getlist('region')
+            categories = request.GET.getlist('category')
+
+            sort   = request.GET.get('sort')
+            offset = int(request.GET.get('offset', 0))
+            limit  = int(request.GET.get('limit', 20))
+
+            q_region = Q()
+            q_category = Q()
+
+            if regions:
+                q_region |= Q(region__id__in = regions)
+
+            if categories:
+                q_category |= Q(category__id__in = categories)
+
+            sort_set = {
+                'avg-price-ascending'  : 'avg_price',
+                'avg-price-descending' : '-avg_price',
+                'min-price-ascending'  : 'min_price',
+                'max-price-descending' : '-max_price',
+                'random'               : '?',
+            }
+
+            order_key = sort_set.get(sort, 'id')
+
+            places = Place.objects.select_related('category', 'region').prefetch_related('placemenu_set__price', 'placemenu_set__menu', 'menus', 'image_set').annotate(
+                min_price = Min('placemenu__price__price'),
+                max_price = Max('placemenu__price__price'),
+                avg_price = Avg('placemenu__price__price')
+                ).filter(q_region & q_category).order_by(order_key)[offset : offset + limit]
+
+            results = [{
+                'place_id'                           : place.id,
+                'place_name'                         : place.name,
+                'place_opening_hours'                : place.opening_hours,
+                'place_maximum_number_of_subscriber' : place.maximum_number_of_subscriber,
+                'place_able_to_reserve'              : place.able_to_reserve,
+                'place_closed_temporarily'           : place.closed_temporarily,
+                'place_category'                     : place.category.name,
+                'place_region'                       : place.region.name,
+                'place_image'                        : place.image_set.all().first().image_url if place.image_set.all() else None,
+                'menus' : [{
+                    'id'           : placemenu.menu.id,
+                    'name'         : placemenu.menu.name ,
+                    'price'        : placemenu.price.price,
+                    'is_signature' : placemenu.is_signature,
+                } for placemenu in place.placemenu_set.all()],
+                'menu_avg_price'                     : place.avg_price,
+                'menu_min_price'                     : place.min_price,
+                'menu_max_price'                     : place.max_price,
+            } for place in places]
+
+            return JsonResponse({'results' : results, 'date' : date}, status = 200)
+
+        except KeyError:
+            return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 맛집 검색 시 나오는 리스트 페이지에 대한 API 구현

<br />

## :: 구현 사항 설명

1. `q 객체`를 활용하여 지역별, 카테고리별 검색 기능 구현
<img width="1195" alt="Screen Shot 2022-07-10 at 8 18 30 AM" src="https://user-images.githubusercontent.com/102043891/178125640-a0de6724-fd61-4736-978e-dc65373c112a.png">

2. `pagination`을 위해 `offset`, `limit` 추가
3. `sort_set`을 활용하여 정렬 기능 추가
4. `annotate`를 활용하여 최소 가격, 최대 가격, 평균 가격 기능 추가
5. unit test 통과
 <img width="1198" alt="Screen Shot 2022-07-10 at 12 00 59 AM" src="https://user-images.githubusercontent.com/102043891/178111393-6778e8ab-8e66-4c0d-9993-a83b8d08a5a9.png">


<br />

## :: 성장 포인트
- `get`이 아닌 `getlist`를 이용하여 같은 종류의 쿼리 파라미터가 중복 될 수 있음을 알게 되었습니다.
- `Q 객체`를 활용하여 `&=`이 아니라 `|=`과 `for 문`을 통한 중복 검색 기능을 알게 되었습니다.
- 해당 테이블이 다른 테이블과 외부 키로 연결 되어 있거나 다대다 관계일 때 어떻게 해당 테이블로 건너갈 수 있는지 직접 `python shell`을 통하여 디버깅할 수 있었습니다.
- `annotate`와 `Avg`, `Min`, `Max`를 활용하여 가격에 대한 평균 값, 최솟값, 최댓값을 구할 수 있었습니다.


<br />

## :: 기타 질문 및 특이 사항
- `query parameter`에서 지역이 '제주시', '서귀포시' 말고 다른 지역들은 `"애월 · 한림"`처럼 `가운뎃점(·)`과` 공백(space)`이 들어갑니다. 제가 알기로는 컨벤션에 들어가기에 부적절한 걸로 아는데, 수정해야 할까요?
- 지역별/카테고리별 검색이 중복이 되어야 해서 `Q 객체`에 `|=`과 `for 문`을 이용하였는데 이렇게 작성하는 게 적절한지 아닌지 멘토님의 의견이 궁금합니다.
- `annotate`를 동시에 3개나 넣다 보니 코드가 불필요하게 길어진 것 같습니다. 좀 더 리팩토링을 할 수 있는 방법이 있을까요?
- `aggregate`는 사용하지 않았는데, 작성한 코드에는 해당 메서드가 필요한지 아닌지 멘토님의 의견이 궁금합니다.
