### PR TITLE
[밥 먹언] 상세 페이지 API 및 유닛 테스트 구현 (places/views.py) (places/tests.py)

### DIFF
--- a/places/tests.py
+++ b/places/tests.py
@@ -68,10 +68,19 @@ class PlaceSearchViewTest(TestCase):
             PlaceMenu(menu_id = 6, place_id = 2, price_id = 16, is_signature = False),
         ])
         Image.objects.bulk_create([
-            Image(image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg', place_id  = 1),
-            Image(image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_TEPcAJMy_8808aea72589ba335d85f349ce8729bbb4144445.jpeg', place_id  = 2),
+            Image(id = 1, image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg', place_id  = 1),
+            Image(id = 51, image_url = 'https://cdn.pixabay.com/photo/2015/07/12/14/26/coffee-842020__480.jpg', place_id  = 1),
+            Image(id = 52, image_url = 'https://media.istockphoto.com/photos/traditional-cafe-picture-id1356951371?b=1&k=20&m=1356951371&s=170667a&w=0&h=OCoZRi_qJmIiUvMRt8qMxHVraRtklgte4QtfDbeFSgM=', place_id  = 1),
+            Image(id = 53, image_url = 'https://cdn.pixabay.com/photo/2014/12/11/02/55/cereals-563796__480.jpg', place_id  = 1),
+            Image(id = 54, image_url = 'https://images.unsplash.com/photo-1481391032119-d89fee407e44?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTR8fGZvb2RzfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60', place_id  = 1),
+            Image(id = 55, image_url = 'https://cdn.pixabay.com/photo/2017/07/28/14/29/macarons-2548827__480.jpg', place_id  = 1),
+            Image(id = 2, image_url = 'https://mustgo.carmore.kr/data/file/matzip/977797506_TEPcAJMy_8808aea72589ba335d85f349ce8729bbb4144445.jpeg', place_id  = 2),
+            Image(id = 56, image_url = 'https://media.istockphoto.com/photos/korean-bbq-picture-id503205965?b=1&k=20&m=503205965&s=170667a&w=0&h=ilozw4fmtVJRaW_J7i5DiGj2CldrECeoCAM-GmuCQlw=', place_id  = 2),
+            Image(id = 57, image_url = 'https://media.istockphoto.com/photos/sharing-good-food-and-wine-with-friend-picture-id949081542?b=1&k=20&m=949081542&s=170667a&w=0&h=HCivTNySVjMQ6xQKVJUhh9Y0EOiHNN0seh_gaPthWWQ=', place_id  = 2),
+            Image(id = 58, image_url = 'https://images.unsplash.com/photo-1590301157890-4810ed352733?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8a29yZWFuJTIwZm9vZHN8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60', place_id  = 2),
+            Image(id = 59, image_url = 'https://images.unsplash.com/photo-1553163147-622ab57be1c7?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8Nnx8a29yZWFuJTIwZm9vZHN8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60', place_id  = 2),
+            Image(id = 60, image_url = 'https://media.istockphoto.com/photos/korean-seafood-tofu-stew-picture-id157774918?b=1&k=20&m=157774918&s=170667a&w=0&h=nEyobW5LyAXhSWQlfIoVEwHgqDsVzYvibCFU2XRZKy0=', place_id  = 2),
         ])
-
 
     def tearDown(self):
         Menu.objects.all().delete()
@@ -252,5 +261,74 @@ class PlaceSearchViewTest(TestCase):
                     }
                 ],
                 "date": "2022-02-07"
+            })
+            self.assertEqual(response.status_code, 200)
+
+    def test_success_place_detail_get(self):
+            client = Client()
+
+            response = client.get('/places/1')
+
+            self.assertEqual(response.json(),{
+                "results": {
+                    "place_id": 1,
+                        "place_name": "토투가커피",
+                        "place_address": "제주특별자치도 제주시 한림읍 귀덕9길 19",
+                        "place_opening_hours": "10:00 - 18:00, 연중무휴",
+                        "place_description": "맞아, 까눌레는 이래야지! 라는 말이 절로 나오는 집!",
+                        "place_maximum_number_of_subscriber": 0,
+                        "place_latitude": "33.44283842",
+                        "place_longitude": "126.28994200",
+                        "place_able_to_reserve": False,
+                        "place_closed_temporarily": False,
+                        "place_category": "카페",
+                        "place_region": "애월_한림",
+                        "place_images": [
+                            {
+                                "id": 1,
+                                "url": "https://mustgo.carmore.kr/data/file/matzip/977797506_dMG6qOYk_bbb37afa85c4c5bf67abe3e40aea39f356c852bf.jpeg"
+                            },
+                            {
+                                "id": 51,
+                                "url": "https://cdn.pixabay.com/photo/2015/07/12/14/26/coffee-842020__480.jpg"
+                            },
+                            {
+                                "id": 52,
+                                "url": "https://media.istockphoto.com/photos/traditional-cafe-picture-id1356951371?b=1&k=20&m=1356951371&s=170667a&w=0&h=OCoZRi_qJmIiUvMRt8qMxHVraRtklgte4QtfDbeFSgM="
+                            },
+                            {
+                                "id": 53,
+                                "url": "https://cdn.pixabay.com/photo/2014/12/11/02/55/cereals-563796__480.jpg"
+                            },
+                            {
+                                "id": 54,
+                                "url": "https://images.unsplash.com/photo-1481391032119-d89fee407e44?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTR8fGZvb2RzfGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=800&q=60"
+                            },
+                            {
+                                "id": 55,
+                                "url": "https://cdn.pixabay.com/photo/2017/07/28/14/29/macarons-2548827__480.jpg"
+                            }
+                        ],
+                        "menus": [
+                            {
+                                "id": 1,
+                                "name": "까눌레",
+                                "price": "3000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 2,
+                                "name": "아메리카노",
+                                "price": "5000",
+                                "is_signature": True
+                            },
+                            {
+                                "id": 3,
+                                "name": "핸드드립",
+                                "price": "6000",
+                                "is_signature": False
+                            }
+                        ]
+                }
             })
             self.assertEqual(response.status_code, 200)

--- a/places/urls.py
+++ b/places/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from places.views import PlaceSearchView, CategoryListView, RegionListView
+from places.views import PlaceSearchView, CategoryListView, RegionListView, PlaceDetailView
 
 urlpatterns = [
     path('/search', PlaceSearchView.as_view()),
+    path('/region', RegionListView.as_view()),
     path('/category', CategoryListView.as_view()),
-    path('/region', RegionListView.as_view())
+    path('/<int:place_id>', PlaceDetailView.as_view()),
 ]

--- a/places/views.py
+++ b/places/views.py
@@ -83,3 +83,35 @@ class PlaceSearchView(View):
 
         except KeyError:
             return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)
+
+class PlaceDetailView(View):
+    def get(self, request, place_id):
+        try:
+            place   = Place.objects.prefetch_related('placemenu_set__price', 'placemenu_set__menu').get(id=place_id)
+            results = {
+                'place_id'                           : place.id,
+                'place_name'                         : place.name,
+                'place_address'                      : place.address,
+                'place_opening_hours'                : place.opening_hours,
+                'place_description'                  : place.description,
+                'place_maximum_number_of_subscriber' : place.maximum_number_of_subscriber,
+                'place_latitude'                     : place.latitude,
+                'place_longitude'                    : place.longitude,
+                'place_able_to_reserve'              : place.able_to_reserve,
+                'place_closed_temporarily'           : place.closed_temporarily,
+                'place_category'                     : place.category.name,
+                'place_region'                       : place.region.name,
+                'place_images'                   : [{
+                    'id'  : image.id,
+                    'url' : image.image_url,
+                    } for image in place.image_set.all()],
+                'menus'                              : [{
+                    'id'           : placemenu.menu.id,
+                    'name'         : placemenu.menu.name ,
+                    'price'        : placemenu.price.price,
+                    'is_signature' : placemenu.is_signature,
+                } for placemenu in place.placemenu_set.all()],
+            }
+            return JsonResponse({'results' : results}, status = 200)
+        except Place.DoesNotExist:
+            return JsonResponse({'message' : 'PLACE_DOES_NOT_EXIST'}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 상세 페이지에 필요한 API 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. `urls.py`의 엔드포인트를 `places/<int:place_id>`의 형식으로
2. `results`에는 상세페이지에 필요한 데이터를 담아 구현하였습니다.
<img width="1681" alt="Screen Shot 2022-07-11 at 8 59 48 AM" src="https://user-images.githubusercontent.com/102043891/178183900-0b72fb3a-a56c-4aa9-a5d2-a598cee0ffcd.png">
4. `tests.py`에 상세페이지 관련 데이터를 넣어 통과했습니다.
<img width="920" alt="Screen Shot 2022-07-11 at 10 02 28 AM" src="https://user-images.githubusercontent.com/102043891/178184331-554a74bc-b59a-43e3-a7a7-25bba6de5772.png">

<br />

## :: 성장 포인트
- 이번에 상세페이지는 처음 해 보는데, 엔드포인트를 `places/<int:place_id>`로 하고, `get`의 parameter에 `place_id`로 넣어 구현 수 있는 걸 알게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 상세 페이지에 예약 기능을 넣으려면 해당 API에 어떻게 추가해야 할지 아직 감을 못 잡겠습니다... 우선 해 보고 다시 알려드리겠습니다!
